### PR TITLE
fix delete usage button

### DIFF
--- a/public/js/value-app.js
+++ b/public/js/value-app.js
@@ -1,4 +1,4 @@
-$( document ).ready(function() {
+$(document).ready(function() {
   // Flash messages
   $(".message .close").on("click", function() {
     $(this)
@@ -15,22 +15,27 @@ $( document ).ready(function() {
   var deleteUseDateButton = ".trash";
   openModal(updateProfileButton);
   openModal(deleteThingButton);
+  openModal(deleteUseDateButton);
 
   // Delete use date modal
   $(deleteUseDateButton).on("click", function() {
-    var date = $(this).siblings("span").text();
+    var date = $(this)
+      .siblings("span")
+      .text();
     var index = $(this).attr("id");
     $("#thisDate").text(date);
     $("#usageDatesIndex").val(index);
     openModal(deleteUseDateButton);
-  })
+  });
 
   // Update per-use cost display based on user input
   $("#newPurchasePrice").on("keyup", function() {
     var input = $("#newPurchasePrice").val();
     var divisor = $("#useCount").val();
-    $("#resultCostPerUse").val(parseFloat(updateCostPerUse(input, divisor)).toFixed(2));
-  })
+    $("#resultCostPerUse").val(
+      parseFloat(updateCostPerUse(input, divisor)).toFixed(2)
+    );
+  });
 });
 
 // Calculate per-use Cost
@@ -41,7 +46,6 @@ function updateCostPerUse(purchasePrice, useCount) {
 
 function openModal(buttonId) {
   $(buttonId).on("click", function() {
-    $(".ui.tiny.modal")
-      .modal("show");
+    $(".ui.tiny.modal").modal("show");
   });
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to ValueMax! Please replace {Please write here} with your description -->

### What was a problem? (include issue # if applicable)
Delete usage button not showing modal on the first click (issue no. #15)

### How does this PR fix the problem?

The issue was that, on the first click, it assigns a listen for a "click event" on the delete button. So on the next click, it then responds to the event and the modal shows. 

Instead of waiting for the first click before the button starts listen for the click event, when the page loads, the event is attached to the button, so the first click will respond and show the modal.

### Check lists (check `x` in `[ ]` of list items)

- [ ] Changes were already discussed in issues (optional but please note here either way)
- [ x] Meaningful commit messages
- [ x] Code runs without any issues
